### PR TITLE
Fix gain calculation for EQ 2nd order low pass filters.

### DIFF
--- a/src/SigmaDSP.cpp
+++ b/src/SigmaDSP.cpp
@@ -476,7 +476,7 @@ void SigmaDSP::EQsecondOrder(uint16_t startMemoryAddress, secondOrderEQ_t &equal
       a1 = -2*cos(w0);
       a2 = 1 - alpha;
       b0 = (1 - cos(w0)) * (gainLinear/2);
-      b1 = 1 - cos(w0)  * gainLinear;
+      b1 = (1 - cos(w0))  * gainLinear;
       b2 = (1 - cos(w0)) * (gainLinear/2);
       break;
 
@@ -520,7 +520,7 @@ void SigmaDSP::EQsecondOrder(uint16_t startMemoryAddress, secondOrderEQ_t &equal
       a1 = -2*cos(w0);
       a2 = 1 - alpha;
       b0 = (1 - cos(w0)) * gainLinear / 2;
-      b1 = 1 - cos(w0) * gainLinear;
+      b1 = (1 - cos(w0)) * gainLinear;
       b2 = (1 - cos(w0)) * gainLinear / 2;
       break;
 
@@ -542,7 +542,7 @@ void SigmaDSP::EQsecondOrder(uint16_t startMemoryAddress, secondOrderEQ_t &equal
       a1 = -2*cos(w0);
       a2 = 1 - alpha;
       b0 = (1 - cos(w0)) * gainLinear / 2;
-      b1 = 1 - cos(w0) * gainLinear;
+      b1 = (1 - cos(w0)) * gainLinear;
       b2 = (1 - cos(w0)) * gainLinear / 2;
       break;
 


### PR DESCRIPTION
Without this fix, a gain other than 0db will cause significant distortion. 