### PR TITLE
Changed polarity of some coefficients

### DIFF
--- a/src/SigmaDSP.cpp
+++ b/src/SigmaDSP.cpp
@@ -648,8 +648,8 @@ void SigmaDSP::EQsecondOrder(uint16_t startMemoryAddress, secondOrderEQ_t &equal
       coefficients[0] = b0/a0;
       coefficients[1] = b1/a0;
       coefficients[2] = b2/a0;
-      coefficients[3] = -1*a1/a0;
-      coefficients[4] = -1*a2/a0;
+      coefficients[3] = 1 * a1/a0;
+      coefficients[4] = 1 * a2/a0;
     }
     else //if(equalizer.phase == parameters::phase::inverted) // 180 deg
     {


### PR DESCRIPTION
I've been playing around with this library and believe that the coefficient calculations for equaliser state may not be correct. I used another calculator (https://www.earlevel.com/main/2013/10/13/biquad-calculator-v2/) to verify my assumptions and I've updated the relevant equations. 

