### PR TITLE
Fix EQSecondOrder butterworth, bessel, bandpass/stop

### DIFF
--- a/src/SigmaDSP.cpp
+++ b/src/SigmaDSP.cpp
@@ -667,7 +667,7 @@ void SigmaDSP::EQsecondOrder(uint16_t startMemoryAddress, secondOrderEQ_t &equal
 
 // Butterworth lowpass
     case parameters::filterType::butterworthLowpass:
-      alpha = sin(w0) / 2.0 * 1/sqrt(2);
+      alpha = sin(w0) / 2.0 * sqrt(2);
       a0 = 1 + alpha;
       a1 = -2*cos(w0);
       a2 = 1 - alpha;
@@ -678,7 +678,7 @@ void SigmaDSP::EQsecondOrder(uint16_t startMemoryAddress, secondOrderEQ_t &equal
 
 // Butterworth highpass
     case parameters::filterType::butterworthHighpass:
-      alpha = sin(w0) / 2.0 * 1/sqrt(2);
+      alpha = sin(w0) / 2.0 * sqrt(2);
       a0 = 1 + alpha;
       a1 = -2*cos(w0);
       a2 = 1 - alpha;
@@ -689,7 +689,7 @@ void SigmaDSP::EQsecondOrder(uint16_t startMemoryAddress, secondOrderEQ_t &equal
 
 // Bessel lowpass
     case parameters::filterType::besselLowpass:
-      alpha = sin(w0) / 2.0 * 1/sqrt(3) ;
+      alpha = sin(w0) / 2.0 * sqrt(3) ;
       a0 = 1 + alpha;
       a1 = -2*cos(w0);
       a2 = 1 - alpha;
@@ -700,7 +700,7 @@ void SigmaDSP::EQsecondOrder(uint16_t startMemoryAddress, secondOrderEQ_t &equal
 
 // Bessel highpass
     case parameters::filterType::besselHighpass:
-      alpha = sin(w0) / 2.0 * 1/sqrt(3) ;
+      alpha = sin(w0) / 2.0 * sqrt(3) ;
       a0 = 1 + alpha;
       a1 = -2*cos(w0);
       a2 = 1 - alpha;

--- a/src/SigmaDSP.cpp
+++ b/src/SigmaDSP.cpp
@@ -645,7 +645,7 @@ void SigmaDSP::EQsecondOrder(uint16_t startMemoryAddress, secondOrderEQ_t &equal
 
 // Bandpass
     case parameters::filterType::bandpass:
-      alpha = sin(w0) * sinh(log(2)/(2 * equalizer.bandwidth * w0/sin(w0)));
+      alpha = sin(w0) * sinh(log(2)/2 * equalizer.bandwidth * w0/sin(w0));
       a0 = 1 + alpha;
       a1 = -2*cos(w0);
       a2 = 1 - alpha;
@@ -656,7 +656,7 @@ void SigmaDSP::EQsecondOrder(uint16_t startMemoryAddress, secondOrderEQ_t &equal
 
 // Bandstop
     case parameters::filterType::bandstop:
-      alpha = sin(w0) * sinh(log(2)/(2 * equalizer.bandwidth * w0/sin(w0)));
+      alpha = sin(w0) * sinh(log(2)/2 * equalizer.bandwidth * w0/sin(w0));
       a0 = 1 + alpha;
       a1 = -2*cos(w0);
       a2 = 1 - alpha;


### PR DESCRIPTION
Thank you for the great library, also to @MaxPayne86 for the aidaDSP lib. 

I found some errors in the biquad coefficients calculation when I measured the filter and plotted it against the analogue prototype:

<img width="1890" height="1396" alt="butterworth_hp_1000Hz_2_ref_wrong_plot" src="https://github.com/user-attachments/assets/13e2e9f1-db2b-421e-8cfc-e9477f6edd49" />

When I compared the formulae with the [Audio EQ Cookbook](https://webaudio.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html) of RBJ I found the Q-factor for the butterworth and bessel filters to be inverted according to formula 7.

Also the Q for the filter bandwidth had a little flaw for alpha (Formula 8). The Band would get audibly narrower with wider bandwidth.  

I fixed those. The rest of the filters I measured were on point.
For your satisfaction a nice peaking filter with -12dB attenuation:

<img width="1890" height="1396" alt="peaking_-12dB_Q1_2000Hz_ref_plot" src="https://github.com/user-attachments/assets/e166f3b3-1a21-4899-ac94-cce0ede40a19" />